### PR TITLE
chat-space 「メッセージ送信非同期化」

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,9 +221,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -264,7 +261,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,65 @@
+$(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      var html =
+       `<div class="right-contents__message__box" data-message-id=${message.id}>
+          <div class="right-contents__message__box__name">
+            <div class="right-contents__message__box__name__user">
+              ${message.user_name}
+            </div>
+            <div class="right-contents__message__box__name__data">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="right-contents__message__box__comment">
+            <p class="right-contents__message__box__comment__body">
+              ${message.body}
+            </p>
+          </div>
+          <img src=${message.image} >
+        </div>`
+      return html;
+    } else {
+      var html =
+       `<div class="right-contents__message__box" data-message-id=${message.id}>
+          <div class="right-contents__message__box__name">
+            <div class="right-contents__message__box__name__user">
+              ${message.user_name}
+            </div>
+            <div class="right-contents__message__box__name__data">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="right-contents__message__box__comment">
+            <p class="right-contents__message__box__comment__body">
+              ${message.body}
+            </p>
+          </div>
+        </div>`
+      return html;
+    };
+  }
+  $('#new_message').on('submit', function(e){
+    e.preventDefault()
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.right-contents__message').append(html);      
+      $('form')[0].reset();
+      $('.right-contents__message__box').animate({ scrollTop: $('.right-contents__message__box')[0].scrollHeight});
+      $('.right-contents__from__box__btn').prop('disabled',false);
+    })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+  });
+  });
+});

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -110,31 +110,27 @@
       height: calc(100vh - 190px);
       background-color: #fafafa;
       padding: 46px 40px;
+      overflow: scroll;
       &__box {
-        height: 54px;
-        margin-bottom: 46px;
+        padding-bottom: 40px;
         &__name {
-          height: 28px;
           display: flex;
-          justify-content: flex-start;
-          p {
-            color: #333333;
-            
+          margin-bottom: 10px;
+          &__user {
+            font-size: 16px;
+            font-weight: bold;
+            color: #434a54;
           }
-          h1 {
-            font-size: 12px;
+          &__data {
+            margin-left: 10px;
             color: #999999;
-            padding-left: 20px;
+            font-size: 12px;
           }
         }
         &__comment {
-          height: 14px;
-          padding-top: 12px;
-          p {
-            color: #434a54;
-            font-size: 14px;
-            line-height: 14px;
-          }
+          margin-bottom: 10px;
+          font-size: 14px;
+          color: #434a54;
         }
       }
     }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,8 +8,10 @@ class MessagesController < ApplicationController
 
   def create
     @message = @group.messages.new(message_params)
-    if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      if @message.save
+        respond_to do |format|
+          format.json
+        end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all' 
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,9 +1,12 @@
 
 .right-contents__message__box
   .right-contents__message__box__name
-    = message.user.name
-    = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+    .right-contents__message__box__name__user
+      = message.user.name
+    .right-contents__message__box__name__data
+      = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
   .right-contents__message__box__comment
     - if message.body.present?
-      = message.body
+      %p.right-contents__message__box__comment__body
+        = message.body
     = image_tag message.image.url, class: 'right-contents__message__box__comment_image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.body @message.body
+json.image @message.image_url
+# binding.pry

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module ChatSpace
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.time_zone = 'Tokyo'
 
     config.generators do |g|
       g.stylesheets false


### PR DESCRIPTION
#what
chat-spaceメッセージ投稿機能の非同期通信
同期通信と違いjsonデータをレスポンスとして返し、画面をリロードせずに動きをつけた。
ビューのブロック分けがいまいちだったので_message.html.hamlと_messages.scssも編集しました。
動画は圧縮しました。

＃why
同期通信では、画面にリダイレクトされるため、ビューが毎回再描画されてしまうので
非同期通信という方法は、現代のWebアプリケーションでは非常に頻繁に使われているから実装した。

[画面収録 2020-02-24 20.30.01.zip](https://github.com/makkei0526/chat-space/files/4244308/2020-02-24.20.30.01.zip)